### PR TITLE
fix: incorrect path in config checking

### DIFF
--- a/src/Exceptions/EmptyContactEmailException.php
+++ b/src/Exceptions/EmptyContactEmailException.php
@@ -8,6 +8,6 @@ class EmptyContactEmailException extends Exception
 {
     public function __construct()
     {
-        parent::__construct('Please fill the `contact.email` field in the app-doc.php config file.');
+        parent::__construct('Please fill the `info.contact.email` field in the app-doc.php config file.');
     }
 }

--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -12,7 +12,6 @@ use RonasIT\Support\AutoDoc\Exceptions\EmptyContactEmailException;
 use RonasIT\Support\AutoDoc\Exceptions\InvalidDriverClassException;
 use RonasIT\Support\AutoDoc\Exceptions\LegacyConfigException;
 use RonasIT\Support\AutoDoc\Exceptions\SpecValidation\InvalidSwaggerSpecException;
-use RonasIT\Support\AutoDoc\Exceptions\SpecValidation\InvalidSwaggerVersionException;
 use RonasIT\Support\AutoDoc\Exceptions\SwaggerDriverClassNotFoundException;
 use RonasIT\Support\AutoDoc\Exceptions\WrongSecurityConfigException;
 use RonasIT\Support\AutoDoc\Interfaces\SwaggerDriverInterface;
@@ -112,7 +111,7 @@ class SwaggerService
 
     protected function generateEmptyData(): array
     {
-        if (!Arr::get($this->config, 'contact.email')) {
+        if (Arr::get($this->config, 'info') && !Arr::get($this->config, 'info.contact.email')) {
             throw new EmptyContactEmailException();
         }
 

--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -111,7 +111,9 @@ class SwaggerService
 
     protected function generateEmptyData(): array
     {
-        if (Arr::get($this->config, 'info') && !Arr::get($this->config, 'info.contact.email')) {
+        // client must enter at least `contact.email` to generate a default `info` block
+        // otherwise an exception will be called
+        if (!empty($this->config['info']) && !Arr::get($this->config, 'info.contact.email')) {
             throw new EmptyContactEmailException();
         }
 

--- a/src/Validators/SwaggerSpecValidator.php
+++ b/src/Validators/SwaggerSpecValidator.php
@@ -316,7 +316,7 @@ class SwaggerSpecValidator
                 break;
             default:
                 $requiredFields = ['type'];
-                $validTypes = self::PRIMITIVE_TYPES;
+                $validTypes = array_merge(self::PRIMITIVE_TYPES, ['object']);
         }
 
         $this->validateFieldsPresent($requiredFields, $paramId);

--- a/tests/SwaggerServiceTest.php
+++ b/tests/SwaggerServiceTest.php
@@ -292,7 +292,7 @@ class SwaggerServiceTest extends TestCase
 
     public function testEmptyContactEmail()
     {
-        config(['auto-doc.contact.email' => null]);
+        config(['auto-doc.info.contact.email' => null]);
 
         $this->expectException(EmptyContactEmailException::class);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,7 +21,7 @@ class TestCase extends BaseTest
     {
         parent::setUp();
 
-        config(['auto-doc.contact.email' => 'your@mail.com']);
+        config(['auto-doc.info.contact.email' => 'your@mail.com']);
     }
 
     public function tearDown(): void

--- a/tests/fixtures/PushDocumentationCommandTest/documentation.json
+++ b/tests/fixtures/PushDocumentationCommandTest/documentation.json
@@ -11,7 +11,7 @@
         "title": "Name of Your Application",
         "termsOfService": "",
         "contact": {
-            "email": null
+            "email": "your@mail.com"
         }
     }
 }

--- a/tests/fixtures/SwaggerServiceTest/tmp_data_request_with_empty_data_jwt.json
+++ b/tests/fixtures/SwaggerServiceTest/tmp_data_request_with_empty_data_jwt.json
@@ -11,7 +11,7 @@
         "title": "Name of Your Application",
         "termsOfService": "",
         "contact": {
-            "email": null
+            "email": "your@mail.com"
         }
     },
     "securityDefinitions": {

--- a/tests/fixtures/SwaggerServiceTest/tmp_data_request_with_empty_data_laravel.json
+++ b/tests/fixtures/SwaggerServiceTest/tmp_data_request_with_empty_data_laravel.json
@@ -11,7 +11,7 @@
         "title": "Name of Your Application",
         "termsOfService": "",
         "contact": {
-            "email": null
+            "email": "your@mail.com"
         }
     },
     "securityDefinitions": {


### PR DESCRIPTION
# Description

Mandatory field `info.contact.email` of `auto-doc.php` was incorrectly validated. It caused errors during the common usage of package.

Fixes #84

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules