### PR TITLE
feat: extends primitive types by date, double, and object

### DIFF
--- a/src/Validators/SwaggerSpecValidator.php
+++ b/src/Validators/SwaggerSpecValidator.php
@@ -42,6 +42,9 @@ class SwaggerSpecValidator
         'integer',
         'number',
         'string',
+        'object',
+        'date',
+        'double',
     ];
 
     public const REQUIRED_FIELDS = [
@@ -316,7 +319,7 @@ class SwaggerSpecValidator
                 break;
             default:
                 $requiredFields = ['type'];
-                $validTypes = array_merge(self::PRIMITIVE_TYPES, ['object']);
+                $validTypes = self::PRIMITIVE_TYPES;
         }
 
         $this->validateFieldsPresent($requiredFields, $paramId);


### PR DESCRIPTION
# Description

`Date`, `double` and `object` were added to the primitive types array to cover cases when we convert validation rules to the new parameter type which is not primitive.

Fixes #104 (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules