### PR TITLE
fix: add image to available content types

### DIFF
--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -312,7 +312,8 @@ class SwaggerService
         $description = $this->getResponseDescription($code);
         $availableContentTypes = [
             'application',
-            'text'
+            'text',
+            'image',
         ];
         $explodedContentType = explode('/', $produce);
 


### PR DESCRIPTION
# Description

Extend available content types for prepare response examples


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules