### PR TITLE
Throw exception for empty or not exists files

### DIFF
--- a/src/Exceptions/DocFileNotExistsException.php
+++ b/src/Exceptions/DocFileNotExistsException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RonasIT\Support\AutoDoc\Exceptions;
+
+use Exception;
+class DocFileNotExistsException extends Exception
+{
+    public function __construct(string $filename)
+    {
+        parent::__construct("Doc file '{$filename}' doesn't exist.");
+    }
+}

--- a/src/Exceptions/DocFileNotExistsException.php
+++ b/src/Exceptions/DocFileNotExistsException.php
@@ -3,6 +3,7 @@
 namespace RonasIT\Support\AutoDoc\Exceptions;
 
 use Exception;
+
 class DocFileNotExistsException extends Exception
 {
     public function __construct(string $filename)

--- a/src/Exceptions/EmptyDocFileException.php
+++ b/src/Exceptions/EmptyDocFileException.php
@@ -3,6 +3,7 @@
 namespace RonasIT\Support\AutoDoc\Exceptions;
 
 use Exception;
+
 class EmptyDocFileException extends Exception
 {
     public function __construct(string $filename)

--- a/src/Exceptions/EmptyDocFileException.php
+++ b/src/Exceptions/EmptyDocFileException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace RonasIT\Support\AutoDoc\Exceptions;
+
+use Exception;
+class EmptyDocFileException extends Exception
+{
+    public function __construct(string $filename)
+    {
+        parent::__construct("Doc file '{$filename}' is empty.");
+    }
+}

--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -8,7 +8,9 @@ use Illuminate\Http\Testing\File;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionClass;
+use RonasIT\Support\AutoDoc\Exceptions\DocFileNotExistsException;
 use RonasIT\Support\AutoDoc\Exceptions\EmptyContactEmailException;
+use RonasIT\Support\AutoDoc\Exceptions\EmptyDocFileException;
 use RonasIT\Support\AutoDoc\Exceptions\InvalidDriverClassException;
 use RonasIT\Support\AutoDoc\Exceptions\LegacyConfigException;
 use RonasIT\Support\AutoDoc\Exceptions\SpecValidation\InvalidSwaggerSpecException;
@@ -692,13 +694,13 @@ class SwaggerService
             $fullFilePath = base_path($filePath);
 
             if (!file_exists($fullFilePath)) {
-                continue;
+                throw new DocFileNotExistsException($fullFilePath);
             }
 
             $fileContent = json_decode(file_get_contents($fullFilePath), true);
 
             if (empty($fileContent)) {
-                continue;
+                throw new EmptyDocFileException($fullFilePath);
             }
 
             try {

--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -671,6 +671,10 @@ class SwaggerService
         return Str::camel($action);
     }
 
+    /**
+     * @deprecated method is not in use
+     * @codeCoverageIgnore
+     */
     protected function saveTempData()
     {
         $exportFile = Arr::get($this->config, 'files.temporary');

--- a/tests/AutoDocControllerTest.php
+++ b/tests/AutoDocControllerTest.php
@@ -3,6 +3,8 @@
 namespace RonasIT\Support\Tests;
 
 use Illuminate\Http\Response;
+use RonasIT\Support\AutoDoc\Exceptions\DocFileNotExistsException;
+use RonasIT\Support\AutoDoc\Exceptions\EmptyDocFileException;
 
 class AutoDocControllerTest extends TestCase
 {
@@ -50,32 +52,32 @@ class AutoDocControllerTest extends TestCase
         $this->assertEqualsJsonFixture('tmp_data_with_additional_paths', $response->json());
     }
 
-    public function getJSONDocumentationInvalidAdditionalDoc(): array
-    {
-        $basePath = 'tests/fixtures/AutoDocControllerTest';
-
-        return [
-            [
-                'additionalDocPath' => 'invalid_path/non_existent_file.json'
-            ],
-            [
-                'additionalDocPath' => $basePath . '/documentation__non_json.txt'
-            ],
-            [
-                'additionalDocPath' => $basePath. '/documentation__invalid_format__missing_field__paths.json'
-            ]
-        ];
-    }
-
-    /**
-     * @dataProvider getJSONDocumentationInvalidAdditionalDoc
-     *
-     * @param string $additionalDocPath
-     */
-    public function testGetJSONDocumentationInvalidAdditionalDoc(string $additionalDocPath)
+    public function getJSONDocumentationDoesntExist()
     {
         config([
-            'auto-doc.additional_paths' => [$additionalDocPath]
+            'auto-doc.additional_paths' => ['invalid_path/non_existent_file.json']
+        ]);
+
+        $this->expectException(DocFileNotExistsException::class);
+
+        $this->json('get', '/auto-doc/documentation');
+    }
+
+    public function getJSONDocumentationIsEmpty()
+    {
+        config([
+            'auto-doc.additional_paths' => ['tests/fixtures/AutoDocControllerTest/documentation__non_json.txt']
+        ]);
+
+        $this->expectException(EmptyDocFileException::class);
+
+        $this->json('get', '/auto-doc/documentation');
+    }
+
+    public function testGetJSONDocumentationInvalidAdditionalDoc()
+    {
+        config([
+            'auto-doc.additional_paths' => ['tests/fixtures/AutoDocControllerTest/documentation__invalid_format__missing_field__paths.json']
         ]);
 
         $response = $this->json('get', '/auto-doc/documentation');


### PR DESCRIPTION
# Description

Added new exceptions for cases when external Open-API doc file (added via `auto-doc.additional_paths`) is not exists or empty (complitely empty or not in a JSOn format).

Fixes #45

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules