### PR TITLE
Dpankratov/disable main doc validation in constructor

### DIFF
--- a/src/Validators/SwaggerSpecValidator.php
+++ b/src/Validators/SwaggerSpecValidator.php
@@ -155,9 +155,9 @@ class SwaggerSpecValidator
 
             $this->validateFieldsPresent(self::REQUIRED_FIELDS['security_definition'], $parentId);
 
-            $this->validateFieldValue("{$parentId}.'type", self::ALLOWED_VALUES['security_definition_type']);
-            $this->validateFieldValue("{$parentId}.'in", self::ALLOWED_VALUES['security_definition_in']);
-            $this->validateFieldValue("{$parentId}.'flow", self::ALLOWED_VALUES['security_definition_flow']);
+            $this->validateFieldValue("{$parentId}.type", self::ALLOWED_VALUES['security_definition_type']);
+            $this->validateFieldValue("{$parentId}.in", self::ALLOWED_VALUES['security_definition_in']);
+            $this->validateFieldValue("{$parentId}.flow", self::ALLOWED_VALUES['security_definition_flow']);
         }
     }
 

--- a/tests/SwaggerServiceTest.php
+++ b/tests/SwaggerServiceTest.php
@@ -277,7 +277,7 @@ class SwaggerServiceTest extends TestCase
     /**
      * @dataProvider getConstructorInvalidTmpData
      *
-     * @param string $tmpDoc
+     * @param string $docFilePath
      * @param string $exception
      * @param string $exceptionMessage
      */

--- a/tests/SwaggerServiceTest.php
+++ b/tests/SwaggerServiceTest.php
@@ -281,13 +281,14 @@ class SwaggerServiceTest extends TestCase
      * @param string $exception
      * @param string $exceptionMessage
      */
-    public function testConstructorInvalidTmpData(string $tmpDoc, string $exception, string $exceptionMessage)
+    public function testGetDocFileContentInvalidTmpData(string $docFilePath, string $exception, string $exceptionMessage)
     {
-        $this->mockDriverGetTpmData($this->getJsonFixture($tmpDoc));
+        $this->mockDriverGetDocumentation($this->getJsonFixture($docFilePath));
+
         $this->expectException($exception);
         $this->expectExceptionMessage($exceptionMessage);
 
-        app(SwaggerService::class);
+        app(SwaggerService::class)->getDocFileContent();
     }
 
     public function testEmptyContactEmail()

--- a/tests/SwaggerServiceTest.php
+++ b/tests/SwaggerServiceTest.php
@@ -271,6 +271,21 @@ class SwaggerServiceTest extends TestCase
                 'exceptionMessage' => "Validation failed. Path parameters cannot be optional. "
                     . "Set required=true for the 'username' parameters at operation 'paths./users.get'."
             ],
+            [
+                'tmpDoc' => 'documentation/invalid_format__security_definition__type',
+                'exception' => InvalidSwaggerSpecException::class,
+                'exceptionMessage' => "Validation failed. Field 'securityDefinitions.0.type' has an invalid value: invalid. Allowed values: basic, apiKey, oauth2."
+            ],
+            [
+                'tmpDoc' => 'documentation/invalid_format__security_definition__flow',
+                'exception' => InvalidSwaggerSpecException::class,
+                'exceptionMessage' => "Validation failed. Field 'securityDefinitions.0.flow' has an invalid value: invalid. Allowed values: implicit, password, application, accessCode."
+            ],
+            [
+                'tmpDoc' => 'documentation/invalid_format__security_definition__in',
+                'exception' => InvalidSwaggerSpecException::class,
+                'exceptionMessage' => "Validation failed. Field 'securityDefinitions.0.in' has an invalid value: invalid. Allowed values: query, header."
+            ],
         ];
     }
 

--- a/tests/fixtures/SwaggerServiceTest/documentation/invalid_format__security_definition__flow.json
+++ b/tests/fixtures/SwaggerServiceTest/documentation/invalid_format__security_definition__flow.json
@@ -1,0 +1,88 @@
+{
+  "swagger": "2.0",
+  "host": "localhost",
+  "basePath": "\/",
+  "schemes": [],
+  "paths": {
+    "\/api\/users":
+    {
+      "post":
+      {
+        "tags": ["api"],
+        "consumes": ["application\/x-www-form-urlencoded"],
+        "produces": ["application\/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "",
+            "required": true,
+           "schema": {
+             "$ref": "#/definitions/apiusersObject"
+           }
+          }
+        ],
+        "responses":
+        {
+          "403":
+          {
+            "description": "Forbidden",
+            "schema":
+            {
+              "example":
+              {
+                "message": "This action is unauthorized."
+              }
+            }
+          }
+        },
+        "security": [],
+        "description": "",
+        "summary": "test"
+      }
+    }
+  },
+  "definitions": {
+    "apiusersObject": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": ""
+        },
+        "user_id": {
+          "type": "integer",
+          "description": "with_to_array_rule_string_name"
+        },
+        "is_email_enabled": {
+          "type": "string",
+          "description": "test_rule_without_to_string"
+        }
+      },
+      "required": {
+        "0": "query"
+      },
+      "example": {
+        "first_name": "andrey",
+        "last_name": "voronin"
+      }
+    }
+  },
+  "info": {
+    "description": "This is automatically collected documentation",
+    "version": "0.0.0",
+    "title": "Name of Your Application",
+    "termsOfService": "",
+    "contact":
+    {
+      "email": "your@email.com"
+    }
+  },
+  "securityDefinitions": [
+    {
+      "type": "basic",
+      "in": "query",
+      "flow": "invalid"
+    }
+  ]
+}

--- a/tests/fixtures/SwaggerServiceTest/documentation/invalid_format__security_definition__in.json
+++ b/tests/fixtures/SwaggerServiceTest/documentation/invalid_format__security_definition__in.json
@@ -1,0 +1,88 @@
+{
+  "swagger": "2.0",
+  "host": "localhost",
+  "basePath": "\/",
+  "schemes": [],
+  "paths": {
+    "\/api\/users":
+    {
+      "post":
+      {
+        "tags": ["api"],
+        "consumes": ["application\/x-www-form-urlencoded"],
+        "produces": ["application\/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "",
+            "required": true,
+           "schema": {
+             "$ref": "#/definitions/apiusersObject"
+           }
+          }
+        ],
+        "responses":
+        {
+          "403":
+          {
+            "description": "Forbidden",
+            "schema":
+            {
+              "example":
+              {
+                "message": "This action is unauthorized."
+              }
+            }
+          }
+        },
+        "security": [],
+        "description": "",
+        "summary": "test"
+      }
+    }
+  },
+  "definitions": {
+    "apiusersObject": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": ""
+        },
+        "user_id": {
+          "type": "integer",
+          "description": "with_to_array_rule_string_name"
+        },
+        "is_email_enabled": {
+          "type": "string",
+          "description": "test_rule_without_to_string"
+        }
+      },
+      "required": {
+        "0": "query"
+      },
+      "example": {
+        "first_name": "andrey",
+        "last_name": "voronin"
+      }
+    }
+  },
+  "info": {
+    "description": "This is automatically collected documentation",
+    "version": "0.0.0",
+    "title": "Name of Your Application",
+    "termsOfService": "",
+    "contact":
+    {
+      "email": "your@email.com"
+    }
+  },
+  "securityDefinitions": [
+    {
+      "type": "basic",
+      "in": "invalid",
+      "flow": "password"
+    }
+  ]
+}

--- a/tests/fixtures/SwaggerServiceTest/documentation/invalid_format__security_definition__type.json
+++ b/tests/fixtures/SwaggerServiceTest/documentation/invalid_format__security_definition__type.json
@@ -1,0 +1,88 @@
+{
+  "swagger": "2.0",
+  "host": "localhost",
+  "basePath": "\/",
+  "schemes": [],
+  "paths": {
+    "\/api\/users":
+    {
+      "post":
+      {
+        "tags": ["api"],
+        "consumes": ["application\/x-www-form-urlencoded"],
+        "produces": ["application\/json"],
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "description": "",
+            "required": true,
+           "schema": {
+             "$ref": "#/definitions/apiusersObject"
+           }
+          }
+        ],
+        "responses":
+        {
+          "403":
+          {
+            "description": "Forbidden",
+            "schema":
+            {
+              "example":
+              {
+                "message": "This action is unauthorized."
+              }
+            }
+          }
+        },
+        "security": [],
+        "description": "",
+        "summary": "test"
+      }
+    }
+  },
+  "definitions": {
+    "apiusersObject": {
+      "type": "object",
+      "properties": {
+        "query": {
+          "type": "string",
+          "description": ""
+        },
+        "user_id": {
+          "type": "integer",
+          "description": "with_to_array_rule_string_name"
+        },
+        "is_email_enabled": {
+          "type": "string",
+          "description": "test_rule_without_to_string"
+        }
+      },
+      "required": {
+        "0": "query"
+      },
+      "example": {
+        "first_name": "andrey",
+        "last_name": "voronin"
+      }
+    }
+  },
+  "info": {
+    "description": "This is automatically collected documentation",
+    "version": "0.0.0",
+    "title": "Name of Your Application",
+    "termsOfService": "",
+    "contact":
+    {
+      "email": "your@email.com"
+    }
+  },
+  "securityDefinitions": [
+    {
+      "type": "invalid",
+      "in": "query",
+      "flow": "password"
+    }
+  ]
+}

--- a/tests/support/Traits/SwaggerServiceMockTrait.php
+++ b/tests/support/Traits/SwaggerServiceMockTrait.php
@@ -60,4 +60,16 @@ trait SwaggerServiceMockTrait
 
         $this->app->instance($driverClass, $driver);
     }
+
+    protected function mockDriverGetDocumentation($data, $driverClass = LocalDriver::class)
+    {
+        $driver = $this->mockClass($driverClass, ['getDocumentation']);
+
+        $driver
+            ->expects($this->exactly(1))
+            ->method('getDocumentation')
+            ->willReturn($data);
+
+        $this->app->instance($driverClass, $driver);
+    }
 }


### PR DESCRIPTION
# Description

Remove open api spec validation on the current documentation in swagger service constructor

## Type of change

Please delete options that are not relevant.

- [x] Refactoring