### PR TITLE
feat: add exception for invalid documentation_viewer configuration.

### DIFF
--- a/src/Exceptions/UnsupportedDocumentationViewerException.php
+++ b/src/Exceptions/UnsupportedDocumentationViewerException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace RonasIT\Support\AutoDoc\Exceptions;
+
+use Exception;
+
+class UnsupportedDocumentationViewerException extends Exception
+{
+    public function __construct(string $invalidViewer)
+    {
+        parent::__construct("The documentation viewer '{$invalidViewer}' does not exists. Please check that the 'documentation_viewer' key of your auto-doc.php config has one of valid values.");
+    }
+}

--- a/src/Exceptions/UnsupportedDocumentationViewerException.php
+++ b/src/Exceptions/UnsupportedDocumentationViewerException.php
@@ -8,6 +8,9 @@ class UnsupportedDocumentationViewerException extends Exception
 {
     public function __construct(string $invalidViewer)
     {
-        parent::__construct("The documentation viewer '{$invalidViewer}' does not exists. Please check that the 'documentation_viewer' key of your auto-doc.php config has one of valid values.");
+        parent::__construct(
+            "The documentation viewer '{$invalidViewer}' does not exists."
+             . " Please check that the 'documentation_viewer' key of your auto-doc.php config has one of valid values."
+        );
     }
 }

--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -96,7 +96,7 @@ class SwaggerService
             throw new LegacyConfigException();
         }
 
-        $documentationViewer = (string)Arr::get($this->config, 'documentation_viewer');
+        $documentationViewer = (string) Arr::get($this->config, 'documentation_viewer');
 
         if (!view()->exists("auto-doc::documentation-{$documentationViewer}")) {
             throw new UnsupportedDocumentationViewerException($documentationViewer);

--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -15,6 +15,7 @@ use RonasIT\Support\AutoDoc\Exceptions\InvalidDriverClassException;
 use RonasIT\Support\AutoDoc\Exceptions\LegacyConfigException;
 use RonasIT\Support\AutoDoc\Exceptions\SpecValidation\InvalidSwaggerSpecException;
 use RonasIT\Support\AutoDoc\Exceptions\SwaggerDriverClassNotFoundException;
+use RonasIT\Support\AutoDoc\Exceptions\UnsupportedDocumentationViewerException;
 use RonasIT\Support\AutoDoc\Exceptions\WrongSecurityConfigException;
 use RonasIT\Support\AutoDoc\Interfaces\SwaggerDriverInterface;
 use RonasIT\Support\AutoDoc\Traits\GetDependenciesTrait;
@@ -56,6 +57,12 @@ class SwaggerService
         'int' => 'integer'
     ];
 
+    protected $documentationViewers = [
+        'swagger',
+        'elements',
+        'rapidoc'
+    ];
+
     public function __construct(Container $container)
     {
         $this->openAPIValidator = app(SwaggerSpecValidator::class);
@@ -93,6 +100,11 @@ class SwaggerService
 
         if (version_compare($packageConfigs['config_version'], $version, '>')) {
             throw new LegacyConfigException();
+        }
+
+        $documentationViewer = (string)Arr::get($this->config, 'documentation_viewer');
+        if (!in_array($documentationViewer, $this->documentationViewers)) {
+            throw new UnsupportedDocumentationViewerException($documentationViewer);
         }
     }
 

--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -57,12 +57,6 @@ class SwaggerService
         'int' => 'integer'
     ];
 
-    protected $documentationViewers = [
-        'swagger',
-        'elements',
-        'rapidoc'
-    ];
-
     public function __construct(Container $container)
     {
         $this->openAPIValidator = app(SwaggerSpecValidator::class);
@@ -103,7 +97,8 @@ class SwaggerService
         }
 
         $documentationViewer = (string)Arr::get($this->config, 'documentation_viewer');
-        if (!in_array($documentationViewer, $this->documentationViewers)) {
+
+        if (!view()->exists("auto-doc::documentation-{$documentationViewer}")) {
             throw new UnsupportedDocumentationViewerException($documentationViewer);
         }
     }

--- a/tests/SwaggerServiceTest.php
+++ b/tests/SwaggerServiceTest.php
@@ -21,6 +21,7 @@ use RonasIT\Support\AutoDoc\Exceptions\SpecValidation\MissingPathParamException;
 use RonasIT\Support\AutoDoc\Exceptions\SpecValidation\MissingPathPlaceholderException;
 use RonasIT\Support\AutoDoc\Exceptions\SpecValidation\MissingRefFileException;
 use RonasIT\Support\AutoDoc\Exceptions\SwaggerDriverClassNotFoundException;
+use RonasIT\Support\AutoDoc\Exceptions\UnsupportedDocumentationViewerException;
 use RonasIT\Support\AutoDoc\Exceptions\WrongSecurityConfigException;
 use RonasIT\Support\AutoDoc\Services\SwaggerService;
 use RonasIT\Support\Tests\Support\Mock\TestNotificationSetting;
@@ -648,5 +649,25 @@ class SwaggerServiceTest extends TestCase
         ]);
 
         $service->addData($request, $response);
+    }
+
+    public function testSetInvalidDocumentationViewer()
+    {
+        config(['auto-doc.documentation_viewer' => 'invalid']);
+
+        $this->expectException(UnsupportedDocumentationViewerException::class);
+        $this->expectExceptionMessage("The documentation viewer 'invalid' does not exists. Please check that the 'documentation_viewer' key of your auto-doc.php config has one of valid values.");
+
+        app(SwaggerService::class);
+    }
+
+    public function testSetNullableDocumentationViewer()
+    {
+        config(['auto-doc.documentation_viewer' => null]);
+
+        $this->expectException(UnsupportedDocumentationViewerException::class);
+        $this->expectExceptionMessage("The documentation viewer '' does not exists. Please check that the 'documentation_viewer' key of your auto-doc.php config has one of valid values.");
+
+        app(SwaggerService::class);
     }
 }

--- a/tests/SwaggerServiceTest.php
+++ b/tests/SwaggerServiceTest.php
@@ -656,7 +656,10 @@ class SwaggerServiceTest extends TestCase
         config(['auto-doc.documentation_viewer' => 'invalid']);
 
         $this->expectException(UnsupportedDocumentationViewerException::class);
-        $this->expectExceptionMessage("The documentation viewer 'invalid' does not exists. Please check that the 'documentation_viewer' key of your auto-doc.php config has one of valid values.");
+        $this->expectExceptionMessage(
+            "The documentation viewer 'invalid' does not exists."
+            . " Please check that the 'documentation_viewer' key of your auto-doc.php config has one of valid values."
+        );
 
         app(SwaggerService::class);
     }
@@ -666,7 +669,10 @@ class SwaggerServiceTest extends TestCase
         config(['auto-doc.documentation_viewer' => null]);
 
         $this->expectException(UnsupportedDocumentationViewerException::class);
-        $this->expectExceptionMessage("The documentation viewer '' does not exists. Please check that the 'documentation_viewer' key of your auto-doc.php config has one of valid values.");
+        $this->expectExceptionMessage(
+            "The documentation viewer '' does not exists."
+            . " Please check that the 'documentation_viewer' key of your auto-doc.php config has one of valid values."
+        );
 
         app(SwaggerService::class);
     }


### PR DESCRIPTION
# Description

Add handling unsupported documentation viewer configuration. Throw the `UnsupportedDocumentationViewerException` exception if an invalid value was provided.

Fixes #93

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules