### PR TITLE
docs: add documentation block with comparison to another generators

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,16 @@
 [![Laravel Swagger](https://github.com/RonasIT/laravel-swagger/actions/workflows/laravel.yml/badge.svg?branch=master)](https://github.com/RonasIT/laravel-swagger/actions/workflows/laravel.yml)
 [![Coverage Status](https://coveralls.io/repos/github/RonasIT/laravel-swagger/badge.svg?branch=master)](https://coveralls.io/github/RonasIT/laravel-swagger?branch=master)
 
+## Comparison to another documentation generators
+
+| | LaravelSwagger | Scramble |
+|-|-|-|
+| Force developers to write tests | + | - |
+| Guarantee that API works | + | - |
+| Integrate without routes modification | + | - |
+| Generate response schema without using JSON Resource class | + | - |
+| Need a sorage to save generated documentation | + | - |
+
 ## Introduction
 
 This plugin is designed to generate documentation for your REST API during the 

--- a/readme.md
+++ b/readme.md
@@ -13,13 +13,13 @@
 
 ## Comparison to another documentation generators
 
-| | LaravelSwagger | Scramble |
-|-|-|-|
-| Force developers to write tests | + | - |
-| Guarantee that API works | + | - |
-| Integrate without routes modification | + | - |
-| Generate response schema without using JSON Resource class | + | - |
-| Need a sorage to save generated documentation | + | - |
+| | LaravelSwagger         | [Scramble](https://github.com/dedoc/scramble) |
+|-|------------------------|----------------------------------------------|
+| Force developers to write tests | :white_check_mark:     | :x:                                          |
+| Guarantee that API works | :white_check_mark:     | :x:                                          |
+| Integrate without routes modification | :white_check_mark:     | :x:                                          |
+| Generate response schema using JSON Resource class | :x: | :white_check_mark:                             |
+| Runtime documentation generation | :x:                    | :white_check_mark:                        |
 
 ## Introduction
 


### PR DESCRIPTION
# Description

Add a table with comparison criteria between LaravelSwagger and other documentation generators

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules