### PR TITLE
Error when handling response with the field name "type"

### DIFF
--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -317,7 +317,7 @@ class SwaggerService
         $properties = Arr::get($this->data['definitions'], $definition, []);
 
         foreach ($content as $name => $value) {
-            $property = Arr::get($properties, $name, []);
+            $property = Arr::get($properties, "properties.{$name}", []);
 
             if (is_null($value)) {
                 $property['nullable'] = true;

--- a/tests/SwaggerServiceTest.php
+++ b/tests/SwaggerServiceTest.php
@@ -535,6 +535,27 @@ class SwaggerServiceTest extends TestCase
         $service->addData($request, $response);
     }
 
+    public function testAddDataWithTypeNameInResponse()
+    {
+        $this->mockDriverGetTpmData($this->getJsonFixture('tmp_data_get_user_request'));
+
+        $service = app(SwaggerService::class);
+
+        $request = $this->generateRequest('get', 'users/{id}/assign-role/{role-id}', [
+            'with' => ['role'],
+            'with_likes_count' => true
+        ], [
+            'id' => 1,
+            'role-id' => 5
+        ]);
+
+        $response = $this->generateResponse('example_success_user_response.json', 200, [
+            'Content-type' => 'application/json'
+        ]);
+
+        $service->addData($request, $response);
+    }
+
     public function testAddDataClosureRequest()
     {
         config(['auto-doc.security' => 'jwt']);

--- a/tests/fixtures/SwaggerServiceTest/example_success_user_response.json
+++ b/tests/fixtures/SwaggerServiceTest/example_success_user_response.json
@@ -5,5 +5,6 @@
     "role": {
         "id": 2,
         "name": "client"
-    }
+    },
+    "type": "reader"
 }

--- a/tests/fixtures/SwaggerServiceTest/tmp_data_get_user_request.json
+++ b/tests/fixtures/SwaggerServiceTest/tmp_data_get_user_request.json
@@ -59,7 +59,8 @@
                                 "role": {
                                     "id": 2,
                                     "name": "client"
-                                }
+                                },
+                                "type": "reader"
                             },
                             "$ref": "#/definitions/getUsers{id}assignRole{roleId}200ResponseObject"
                         }
@@ -87,6 +88,9 @@
                 },
                 "role": {
                     "type": "array"
+                },
+                "type": {
+                    "type": "string"
                 }
             }
         }

--- a/tests/support/Traits/SwaggerServiceMockTrait.php
+++ b/tests/support/Traits/SwaggerServiceMockTrait.php
@@ -12,7 +12,7 @@ trait SwaggerServiceMockTrait
         $tmpData,
         $savedTmpData = null,
         $driverClass = LocalDriver::class
-    ) {
+    ): void {
         $driver = $this->mockClass($driverClass, ['getTmpData', 'saveTmpData']);
 
         $driver
@@ -32,8 +32,11 @@ trait SwaggerServiceMockTrait
         $this->app->instance($driverClass, $driver);
     }
 
-    protected function mockDriverGetPreparedAndSaveTpmData($getTmpData, $saveTmpData, $driverClass = LocalDriver::class)
-    {
+    protected function mockDriverGetPreparedAndSaveTpmData(
+        $getTmpData,
+        $saveTmpData,
+        $driverClass = LocalDriver::class
+    ): void {
         $driver = $this->mockClass($driverClass, ['getTmpData', 'saveTmpData']);
 
         $driver
@@ -49,7 +52,7 @@ trait SwaggerServiceMockTrait
         $this->app->instance($driverClass, $driver);
     }
 
-    protected function mockDriverGetTpmData($tmpData, $driverClass = LocalDriver::class)
+    protected function mockDriverGetTpmData($tmpData, $driverClass = LocalDriver::class): void
     {
         $driver = $this->mockClass($driverClass, ['getTmpData']);
 
@@ -61,7 +64,7 @@ trait SwaggerServiceMockTrait
         $this->app->instance($driverClass, $driver);
     }
 
-    protected function mockDriverGetDocumentation($data, $driverClass = LocalDriver::class)
+    protected function mockDriverGetDocumentation($data, $driverClass = LocalDriver::class): void
     {
         $driver = $this->mockClass($driverClass, ['getDocumentation']);
 
@@ -73,7 +76,7 @@ trait SwaggerServiceMockTrait
         $this->app->instance($driverClass, $driver);
     }
 
-    protected function mockDriverSaveData($driverClass = LocalDriver::class)
+    protected function mockDriverSaveData($driverClass = LocalDriver::class): void
     {
         $driver = $this->mockClass($driverClass, ['saveData']);
 


### PR DESCRIPTION
# Description

We have an issue when the response contains a field with the name `type`. Here is an example of response structure:
```json
{
  "type": "object",
  "properties": {
    "id": {
      "type": "integer"
    },
    "type": {
      "type": "string"
    },
    "comment": {
      "type": "string",
      "nullable": true
    },
    "color_code": {
      "nullable": true,
      "type": "string"
    }
  }
}
```

When we are trying to [get the definition of the field](https://github.com/RonasIT/laravel-swagger/blob/master/src/Services/SwaggerService.php#L320) the following error occurs:
```bash
TypeError: Cannot access offset of type string on string in /app/vendor/ronasit/laravel-swagger/src/Services/SwaggerService.php:325
```

The reason is that the `Arr::get` takes the first occurrence on the `type` in the array, not the correct one.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules