### PR TITLE
fix: missed response definition when the content of response was empty

### DIFF
--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -296,14 +296,10 @@ class SwaggerService
 
     protected function saveResponseSchema(?array $content, string $definition): void
     {
-        if (empty($content)) {
-            return;
-        }
-
         $schemaProperties = [];
         $schemaType = 'object';
 
-        if (array_is_list($content)) {
+        if (!empty($content) && array_is_list($content)) {
             $this->saveListResponseDefinitions($content, $schemaProperties);
 
             $schemaType = 'array';
@@ -366,7 +362,7 @@ class SwaggerService
 
         $responseExampleLimitCount = config('auto-doc.response_example_limit_count');
 
-        $content = json_decode($response->getContent(), true);
+        $content = json_decode($response->getContent(), true) ?? [];
 
         if (!empty($responseExampleLimitCount)) {
             if (!empty($content['data'])) {

--- a/tests/fixtures/SwaggerServiceTest/tmp_data_put_user_request_with_early_generated_doc.json
+++ b/tests/fixtures/SwaggerServiceTest/tmp_data_put_user_request_with_early_generated_doc.json
@@ -103,7 +103,7 @@
           "204": {
             "description": "Operation successfully done",
             "schema": {
-              "example": null,
+              "example": [],
               "$ref": "#/definitions/patchUsers{id}204ResponseObject"
             }
           }
@@ -141,6 +141,10 @@
         "query": null
       },
       "required": ["query"]
+    },
+    "patchUsers{id}204ResponseObject": {
+      "type": "object",
+      "properties": []
     }
   },
   "info": {


### PR DESCRIPTION
# Description

If the response contains no data (eg. delete or put) we ignore them and don't save the definition of such response into the `definitions` section of the `documentation.json` file. At the same time, the `paths.**.responses` section still contains names of such definitions. So it raises an exception during OpenAPI file validation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules