### PR TITLE
fix: documentation creates only for the last test case

### DIFF
--- a/src/Tests/PhpUnitEventSubscribers/SwaggerSaveDocumentationSubscriber.php
+++ b/src/Tests/PhpUnitEventSubscribers/SwaggerSaveDocumentationSubscriber.php
@@ -3,27 +3,24 @@
 namespace RonasIT\Support\AutoDoc\Tests\PhpUnitEventSubscribers;
 
 use Illuminate\Contracts\Console\Kernel;
-use Illuminate\Foundation\Application;
-use PHPUnit\Event\Test\AfterLastTestMethodFinished;
-use PHPUnit\Event\Test\AfterLastTestMethodFinishedSubscriber;
+use PHPUnit\Event\Application\Finished;
+use PHPUnit\Event\Application\FinishedSubscriber;
 use RonasIT\Support\AutoDoc\Services\SwaggerService;
 
-final class SwaggerSaveDocumentationSubscriber implements AfterLastTestMethodFinishedSubscriber
+final class SwaggerSaveDocumentationSubscriber implements FinishedSubscriber
 {
-    public function notify(AfterLastTestMethodFinished $event): void
+    public function notify(Finished $event): void
     {
         $this->createApplication();
 
         app(SwaggerService::class)->saveProductionData();
     }
 
-    protected function createApplication(): Application
+    protected function createApplication(): void
     {
         $app = require base_path('bootstrap/app.php');
 
         $app->loadEnvironmentFrom('.env.testing');
         $app->make(Kernel::class)->bootstrap();
-
-        return $app;
     }
 }


### PR DESCRIPTION
# Description

The documentation generates only for the single test case. So the final `documentation.json` file contains information from the last test case. The reason is the incorrect event of PHPUnit. I changed `PHPUnit\Event\Test\AfterLastTestMethodFinished` to `PHPUnit\Event\Application\Finished` and as a result, a subscriber will run only when all tests finish.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules