### PR TITLE
doc: update readme, add migration guide

### DIFF
--- a/MIGRATION-GUIDES.md
+++ b/MIGRATION-GUIDES.md
@@ -8,4 +8,6 @@ The base namespace of the package had also been changed, so you need to use new 
   `\RonasIT\Support\AutoDoc\Http\Middleware\AutoDocMiddleware::class` to
   `\RonasIT\AutoDoc\Http\Middleware\AutoDocMiddleware::class`;
 - `tests/TestCase.php`, change namespace of `\RonasIT\Support\AutoDoc\Tests\AutoDocTestCaseTrait` to
-  `\RonasIT\AutoDoc\Tests\AutoDocTestCaseTrait`;
+  `\RonasIT\AutoDoc\Traits\AutoDocTestCaseTrait`;
+- `phpunit.xml`, change namespace of extension from `RonasIT\Support\AutoDoc\Tests\PhpUnitExtensions\SwaggerExtension` to
+  `RonasIT\AutoDoc\Support\PHPUnit\Extensions\SwaggerExtension`

--- a/MIGRATION-GUIDES.md
+++ b/MIGRATION-GUIDES.md
@@ -1,0 +1,11 @@
+# 3.0.1-beta
+
+As package starting to work with new Open API specification, need to regenerate documentation file.
+
+The base namespace of the package had also been changed, so you need to use new namespace in:
+
+- `bootstrap\app.php` (`Http/Kernel.php` for Laravel <= 10), change namespace of
+  `\RonasIT\Support\AutoDoc\Http\Middleware\AutoDocMiddleware::class` to
+  `\RonasIT\AutoDoc\Http\Middleware\AutoDocMiddleware::class`;
+- `tests/TestCase.php`, change namespace of `\RonasIT\Support\AutoDoc\Tests\AutoDocTestCaseTrait` to
+  `\RonasIT\AutoDoc\Tests\AutoDocTestCaseTrait`;

--- a/MIGRATION-GUIDES.md
+++ b/MIGRATION-GUIDES.md
@@ -10,4 +10,6 @@ The base namespace of the package had also been changed, so you need to use new 
 - `tests/TestCase.php`, change namespace of `\RonasIT\Support\AutoDoc\Tests\AutoDocTestCaseTrait` to
   `\RonasIT\AutoDoc\Traits\AutoDocTestCaseTrait`;
 - `phpunit.xml`, change namespace of extension from `RonasIT\Support\AutoDoc\Tests\PhpUnitExtensions\SwaggerExtension` to
-  `RonasIT\AutoDoc\Support\PHPUnit\Extensions\SwaggerExtension`
+  `RonasIT\AutoDoc\Support\PHPUnit\Extensions\SwaggerExtension`;
+- your custom documentation drivers, change interface from `RonasIT\AutoDoc\Interfaces\SwaggerDriverInterface` to
+  `RonasIT\AutoDoc\Contracts\SwaggerDriverContract`.

--- a/MIGRATION-GUIDES.md
+++ b/MIGRATION-GUIDES.md
@@ -5,8 +5,8 @@ As package starting to work with new Open API specification, need to regenerate 
 The base namespace of the package had also been changed, so you need to use new namespace in:
 
 - `bootstrap\app.php` (`Http/Kernel.php` for Laravel <= 10), change namespace of
-  `\RonasIT\Support\AutoDoc\Http\Middleware\AutoDocMiddleware::class` to
-  `\RonasIT\AutoDoc\Http\Middleware\AutoDocMiddleware::class`;
+  `\RonasIT\Support\AutoDoc\Http\Middleware\AutoDocMiddleware` to
+  `\RonasIT\AutoDoc\Http\Middleware\AutoDocMiddleware`;
 - `tests/TestCase.php`, change namespace of `\RonasIT\Support\AutoDoc\Tests\AutoDocTestCaseTrait` to
   `\RonasIT\AutoDoc\Traits\AutoDocTestCaseTrait`;
 - `phpunit.xml`, change namespace of extension from `RonasIT\Support\AutoDoc\Tests\PhpUnitExtensions\SwaggerExtension` to

--- a/config/auto-doc.php
+++ b/config/auto-doc.php
@@ -110,7 +110,7 @@ return [
     |
     | The name of driver, which will collect and save documentation
     | Feel free to use your own driver class which should be inherited from
-    | `RonasIT\AutoDoc\Interfaces\SwaggerDriverInterface` interface,
+    | `RonasIT\AutoDoc\Contracts\SwaggerDriverContract` interface,
     | or one of our drivers from the `drivers` config:
     */
     'driver' => env('SWAGGER_DRIVER', 'local'),

--- a/config/auto-doc.php
+++ b/config/auto-doc.php
@@ -184,5 +184,5 @@ return [
         'development',
     ],
 
-    'config_version' => '2.7',
+    'config_version' => '2.8',
 ];

--- a/config/auto-doc.php
+++ b/config/auto-doc.php
@@ -51,8 +51,8 @@ return [
         ],
         'license' => [
             'name' => '',
-            'url' => ''
-        ]
+            'url' => '',
+        ],
     ],
 
     /*
@@ -80,13 +80,13 @@ return [
         'jwt' => [
             'type' => 'apiKey',
             'name' => 'Authorization',
-            'in' => 'header'
+            'in' => 'header',
         ],
         'laravel' => [
             'type' => 'apiKey',
             'name' => '__ym_uid',
-            'in' => 'cookie'
-        ]
+            'in' => 'cookie',
+        ],
     ],
 
     'defaults' => [
@@ -99,8 +99,8 @@ return [
         'code-descriptions' => [
             '200' => 'Operation successfully done',
             '204' => 'Operation successfully done',
-            '404' => 'This entity not found'
-        ]
+            '404' => 'This entity not found',
+        ],
     ],
 
     /*
@@ -147,7 +147,7 @@ return [
             */
             'disk' => env('SWAGGER_STORAGE_DRIVER_DISK', 'public'),
             'production_path' => 'documentation.json',
-        ]
+        ],
     ],
 
     /*

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,23 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="bootstrap/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage/>
-  <testsuites>
-    <testsuite name="Application Test Suite">
-      <directory suffix="Test.php">./tests</directory>
-    </testsuite>
-  </testsuites>
-  <php>
-    <env name="APP_ENV" value="testing"/>
-    <env name="CACHE_DRIVER" value="array"/>
-    <env name="SESSION_DRIVER" value="array"/>
-    <env name="QUEUE_DRIVER" value="sync"/>
-  </php>
-  <source>
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-    <exclude>
-      <file>./app/Http/routes.php</file>
-    </exclude>
-  </source>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
+         bootstrap="bootstrap/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
+    <coverage/>
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="QUEUE_DRIVER" value="sync"/>
+    </php>
+    <source>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+        <exclude>
+            <file>./app/Http/routes.php</file>
+        </exclude>
+    </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,3 +29,5 @@
         </exclude>
     </source>
 </phpunit>
+
+

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,7 +18,6 @@
     </include>
     <exclude>
       <file>./app/Http/routes.php</file>
-      <directory suffix=".php">./src/Tests</directory>
     </exclude>
   </source>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,5 +29,3 @@
         </exclude>
     </source>
 </phpunit>
-
-

--- a/readme.md
+++ b/readme.md
@@ -30,37 +30,51 @@ passing PHPUnit tests.
 
 1. Install the package using the following command: `composer require ronasit/laravel-swagger`
 
-    > ***Note***
-    > 
-    > For Laravel 5.5 or later the package will be auto-discovered.
-    > For older versions add the `AutoDocServiceProvider` to the
-    > providers array in `config/app.php` as follow:
-    > 
-    > ```php
-    > 'providers' => [
-    >    // ...
-    >    RonasIT\AutoDoc\AutoDocServiceProvider::class,
-    > ],
-    > ```
+> ***Note***
+> 
+> For Laravel 5.5 or later the package will be auto-discovered.
+> For older versions add the `AutoDocServiceProvider` to the
+> providers array in `config/app.php` as follow:
+> 
+> ```php
+> 'providers' => [
+>     ...
+>     RonasIT\AutoDoc\AutoDocServiceProvider::class,
+> ],
+> ```
 
- 1. Run `php artisan vendor:publish`
- 2. Add `\RonasIT\AutoDoc\Http\Middleware\AutoDocMiddleware::class` middleware to the global HTTP middleware stack in `Http/Kernel.php`.
- 3. Add `\RonasIT\AutoDoc\Tests\AutoDocTestCaseTrait` trait to `tests/TestCase.php`
- 4. Configure documentation saving using one of the next ways:
-   - Add `SwaggerExtension` to the `<extensions>` block of your `phpunit.xml`.
-    **Please note that this way will be removed after updating**
-    **PHPUnit up to 10 version (https://github.com/sebastianbergmann/phpunit/issues/4676)**
-        ```xml
-        <extensions>
-            <extension class="RonasIT\AutoDoc\Tests\PhpUnitExtensions\SwaggerExtension"/>
-        </extensions>
-        <testsuites>
-            <testsuite name="Feature">
-                <directory suffix="Test.php">./tests/Feature</directory>
-            </testsuite>
-        </testsuites>
-        ```
-   - Call `php artisan swagger:push-documentation` console command after
+2. Run `php artisan vendor:publish --provider=RonasIT\\AutoDoc\\AutoDocServiceProvider`
+1. Add `\RonasIT\AutoDoc\Http\Middleware\AutoDocMiddleware::class` middleware to the global HTTP middleware list `bootstrap\app.php`:
+
+```php
+    return Application::configure(basePath: dirname(__DIR__))
+        ->withMiddleware(function (Middleware $middleware) {
+            $middleware->use([
+                ...
+                \RonasIT\AutoDoc\Http\Middleware\AutoDocMiddleware::class,
+            ]);
+        });
+```
+
+4. Add `\RonasIT\AutoDoc\Tests\AutoDocTestCaseTrait` trait to `tests/TestCase.php`
+1. Configure documentation saving using one of the next ways:
+  - Add `SwaggerExtension` to the `<extensions>` block of your `phpunit.xml`.
+  **Please note that this way will be removed after updating**
+  **PHPUnit up to 10 version (https://github.com/sebastianbergmann/phpunit/issues/4676)**
+
+  ```xml
+  <phpunit>
+      <extensions>
+          <bootstrap class="RonasIT\AutoDoc\Tests\PhpUnitExtensions\SwaggerExtension"/>
+      </extensions>
+      <testsuites>
+          <testsuite name="Feature">
+              <directory suffix="Test.php">./tests/Feature</directory>
+          </testsuite>
+      </testsuites>
+  </phpunit>
+  ```
+  - Call `php artisan swagger:push-documentation` console command after
     the `tests` stage in your CI/CD configuration
 
 ## Usage
@@ -205,6 +219,10 @@ This change is reflected immediately, without the need to rebuild the documentat
 
 The package supports the integration of the primary documentation with additional valid
 OpenAPI files specified in the `additional_paths` configuration.
+
+## Migration guides
+
+[3.0.1-beta](MIGRATION-GUIDES.md#301-beta)
 
 ## Contributing
 

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ passing PHPUnit tests.
         });
 ```
 
-4. Add `\RonasIT\AutoDoc\Tests\AutoDocTestCaseTrait` trait to `tests/TestCase.php`
+4. Add `\RonasIT\AutoDoc\Traits\AutoDocTestCaseTrait` trait to `tests/TestCase.php`
 1. Configure documentation saving using one of the next ways:
   - Add `SwaggerExtension` to the `<extensions>` block of your `phpunit.xml`.
   **Please note that this way will be removed after updating**
@@ -65,7 +65,7 @@ passing PHPUnit tests.
   ```xml
   <phpunit>
       <extensions>
-          <bootstrap class="RonasIT\AutoDoc\Tests\PhpUnitExtensions\SwaggerExtension"/>
+          <bootstrap class="RonasIT\AutoDoc\Support\PHPUnit\Extensions\SwaggerExtension"/>
       </extensions>
       <testsuites>
           <testsuite name="Feature">
@@ -134,7 +134,7 @@ passing PHPUnit tests.
     > 
     > For correct working of plugin you'll have to dispose all the validation rules 
     > in the `rules()` method of your request class. Also, your request class
-    > must be connected to the controller via [dependency injection](https://laravel.com/docs/9.x/container#introduction).
+    > must be connected to the controller via [dependency injection](https://laravel.com/docs/11.x/container#introduction).
     > Plugin will take validation rules from the request class and generate fields description
     > of input parameter.
 

--- a/readme.md
+++ b/readme.md
@@ -205,7 +205,7 @@ You can use the following annotations in your request classes to customize docum
 
 ### Custom driver
 
-You can specify the way to collect documentation by creating your own custom driver.
+You can specify the way to collect and view documentation by creating your own custom driver.
 
 You can find example of drivers [here](https://github.com/RonasIT/laravel-swagger/tree/master/src/Drivers).
 

--- a/src/Contracts/SwaggerDriverContract.php
+++ b/src/Contracts/SwaggerDriverContract.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace RonasIT\AutoDoc\Interfaces;
+namespace RonasIT\AutoDoc\Contracts;
 
-interface SwaggerDriverInterface
+interface SwaggerDriverContract
 {
     /**
      * Save temporary data

--- a/src/Drivers/BaseDriver.php
+++ b/src/Drivers/BaseDriver.php
@@ -2,9 +2,9 @@
 
 namespace RonasIT\AutoDoc\Drivers;
 
-use RonasIT\AutoDoc\Interfaces\SwaggerDriverInterface;
+use RonasIT\AutoDoc\Contracts\SwaggerDriverContract;
 
-abstract class BaseDriver implements SwaggerDriverInterface
+abstract class BaseDriver implements SwaggerDriverContract
 {
     protected string $tempFilePath;
 

--- a/src/Services/SwaggerService.php
+++ b/src/Services/SwaggerService.php
@@ -17,13 +17,13 @@ use RonasIT\AutoDoc\Exceptions\SpecValidation\InvalidSwaggerSpecException;
 use RonasIT\AutoDoc\Exceptions\SwaggerDriverClassNotFoundException;
 use RonasIT\AutoDoc\Exceptions\UnsupportedDocumentationViewerException;
 use RonasIT\AutoDoc\Exceptions\WrongSecurityConfigException;
-use RonasIT\AutoDoc\Interfaces\SwaggerDriverInterface;
+use RonasIT\AutoDoc\Contracts\SwaggerDriverContract;
 use RonasIT\AutoDoc\Traits\GetDependenciesTrait;
 use RonasIT\AutoDoc\Validators\SwaggerSpecValidator;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * @property SwaggerDriverInterface $driver
+ * @property SwaggerDriverContract $driver
  */
 class SwaggerService
 {
@@ -124,7 +124,7 @@ class SwaggerService
             $this->driver = app($className);
         }
 
-        if (!$this->driver instanceof SwaggerDriverInterface) {
+        if (!$this->driver instanceof SwaggerDriverContract) {
             throw new InvalidDriverClassException($driver);
         }
     }

--- a/src/Support/PHPUnit/EventSubscribers/SwaggerSaveDocumentationSubscriber.php
+++ b/src/Support/PHPUnit/EventSubscribers/SwaggerSaveDocumentationSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RonasIT\AutoDoc\Tests\PhpUnitEventSubscribers;
+namespace RonasIT\AutoDoc\Support\PHPUnit\EventSubscribers;
 
 use Illuminate\Contracts\Console\Kernel;
 use PHPUnit\Event\Application\Finished;

--- a/src/Support/PHPUnit/Extensions/SwaggerExtension.php
+++ b/src/Support/PHPUnit/Extensions/SwaggerExtension.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace RonasIT\AutoDoc\Tests\PhpUnitExtensions;
+namespace RonasIT\AutoDoc\Support\PHPUnit\Extensions;
 
 use PHPUnit\Runner\Extension\Extension as PhpunitExtension;
 use PHPUnit\Runner\Extension\Facade as EventFacade;
 use PHPUnit\Runner\Extension\ParameterCollection;
 use PHPUnit\TextUI\Configuration\Configuration;
-use RonasIT\AutoDoc\Tests\PhpUnitEventSubscribers\SwaggerSaveDocumentationSubscriber;
+use RonasIT\AutoDoc\Support\PHPUnit\EventSubscribers\SwaggerSaveDocumentationSubscriber;
 
 final class SwaggerExtension implements PhpunitExtension
 {

--- a/src/Traits/AutoDocTestCaseTrait.php
+++ b/src/Traits/AutoDocTestCaseTrait.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RonasIT\AutoDoc\Tests;
+namespace RonasIT\AutoDoc\Traits;
 
 use RonasIT\AutoDoc\Http\Middleware\AutoDocMiddleware;
 


### PR DESCRIPTION
# Description

Update outdated readme file, fix namespace for autodoc trait and phpunit extensions

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules