### PR TITLE
[Fix] Implicitly marking a parameter as nullable is deprecated

### DIFF
--- a/src/Exceptions/FileNotFoundException.php
+++ b/src/Exceptions/FileNotFoundException.php
@@ -6,7 +6,7 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException as BaseException;
 
 class FileNotFoundException extends BaseException
 {
-    public function __construct(string $filePath = null)
+    public function __construct(?string $filePath = null)
     {
         parent::__construct("Documentation file not found {$filePath}");
     }

--- a/src/Exceptions/MissedProductionFilePathException.php
+++ b/src/Exceptions/MissedProductionFilePathException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class MissedProductionFilePathException extends Exception
 {
-    public function __construct($message = null, $code = 0, Exception $previous = null)
+    public function __construct($message = null, $code = 0, ?Exception $previous = null)
     {
         $message = $message ?? 'Production file path missed in config';
 

--- a/src/Exceptions/MissedRemoteDocumentationUrlException.php
+++ b/src/Exceptions/MissedRemoteDocumentationUrlException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class MissedRemoteDocumentationUrlException extends Exception
 {
-    public function __construct($message = null, $code = 0, Exception $previous = null)
+    public function __construct($message = null, $code = 0, ?Exception $previous = null)
     {
         $message = $message ?? 'Remote documentation url missed in config. Please set SWAGGER_REMOTE_DRIVER_URL env variable to define this one.';
 

--- a/src/Exceptions/SpecValidation/MissingFieldException.php
+++ b/src/Exceptions/SpecValidation/MissingFieldException.php
@@ -4,7 +4,7 @@ namespace RonasIT\AutoDoc\Exceptions\SpecValidation;
 
 class MissingFieldException extends InvalidSwaggerSpecException
 {
-    public function __construct(array $missingFields, string $parentField = null)
+    public function __construct(array $missingFields, ?string $parentField = null)
     {
         $fieldsString = implode(', ', $missingFields);
 


### PR DESCRIPTION
The codebase contains deprecation errors related to implicit nullable parameters in PHP 8.4.